### PR TITLE
nuevo método validacion que deja vacío el buffer cin; usado en Menu

### DIFF
--- a/Menu.cpp
+++ b/Menu.cpp
@@ -5,6 +5,7 @@
 using namespace std;
 
 #include "Menu.h"
+#include "func_utiles.h"
 
 
 Menu::Menu(const vector<string> &opciones, string titulo) : _opciones(opciones), _titulo(titulo) {}
@@ -22,12 +23,9 @@ int Menu::mostrar()
                 }
 
             cout << "Seleccione una opcion (0 para salir/volver): ";
-            cin >> opcionElegida;
+            opcionElegida =obtenerNumeroEntero("Seleccione una opcion (0 para salir/volver): ");
             cout << endl ;
 
-
-            cin.clear();
-            cin.ignore();
             if (opcionElegida < 0 || opcionElegida > tamanio)
                 {
                     cout << endl << "Opcion no valida. Vuelva a intentarlo" << endl << endl;

--- a/func_utiles.cpp
+++ b/func_utiles.cpp
@@ -11,3 +11,27 @@ bool cargarCadenaConString(std::string input, char* output, size_t tamanioOutput
 
     return (largoInput < (int)tamanioOutput);
 }
+
+
+int obtenerNumeroEntero(std::string mensajeError)
+{
+    while (true)
+        {
+            std::string input = "";
+            getline(std::cin, input);
+            int resultado;
+            bool salir=true;
+
+            try
+                {
+                    resultado = stoi(input);
+                }
+            catch (...)
+                {
+                    std::cout << mensajeError;
+                    salir = false;
+                }
+
+            if (salir) return resultado;
+        }
+}

--- a/func_utiles.cpp
+++ b/func_utiles.cpp
@@ -35,3 +35,26 @@ int obtenerNumeroEntero(std::string mensajeError)
             if (salir) return resultado;
         }
 }
+
+float obtenerNumeroDecimal(std::string mensajeError)
+{
+    while (true)
+        {
+            std::string input = "";
+            getline(std::cin, input);
+            float resultado;
+            bool salir=true;
+
+            try
+                {
+                    resultado = stof(input);
+                }
+            catch (...)
+                {
+                    std::cout << mensajeError;
+                    salir = false;
+                }
+
+            if (salir) return resultado;
+        }
+}

--- a/func_utiles.h
+++ b/func_utiles.h
@@ -8,58 +8,77 @@
 /// Devuelve true si el input cabe en el output. Trunca el input si es necesario. Agrega terminación nula al final.
 bool cargarCadenaConString(std::string input, char* output, size_t tamanioOutput);
 
+/// Obtiene un entero con getline, dejando vacío el buffer de cin
+int obtenerNumeroEntero(std::string mensajeError="Valor incorrecto. Ingrese un número entero: ");
+
 /// Valida datos de tipo int y float
 template<typename T>
-    T validar(std::string mensaje) {
-        T entrada;
-        while (true) {
+T validar(std::string mensaje)
+{
+    T entrada;
+    while (true)
+        {
             std::cin >> entrada;
 
-            if (std::cin.fail()) {
-                std::cin.clear();
-                std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-                std::cout << mensaje;
-            } else {
-                // Verificar si hay caracteres no válidos en el búfer
-                char c;
-                std::cin.get(c);
-                if (c != '\n' && !std::isdigit(c)) {
+            if (std::cin.fail())
+                {
+                    std::cin.clear();
                     std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-                    std::cout << "Entrada no válida. Intente de nuevo." << std::endl;
-                } else {
-                    break;
+                    std::cout << mensaje;
                 }
-            }
+            else
+                {
+                    // Verificar si hay caracteres no válidos en el búfer
+                    char c;
+                    std::cin.get(c);
+                    if (c != '\n' && !std::isdigit(c))
+                        {
+                            std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+                            std::cout << mensaje<< std::endl;
+                        }
+                    else
+                        {
+                            break;
+                        }
+                }
         }
 
-        return entrada;
-    }
+    return entrada;
+}
 
 template<typename T>
-    T validar() {
-        T entrada;
-        while (true) {
+T validar()
+{
+    T entrada;
+    while (true)
+        {
             std::cin >> entrada;
 
-            if (std::cin.fail()) {
-                std::cin.clear();
-                std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-                std::cout << "Entrada no válida. Intente de nuevo." << std::endl;
-            } else {
-                // Verificar si hay caracteres no válidos en el búfer
-                char c;
-                std::cin.get(c);
-                if (c != '\n' && !std::isdigit(c)) {
+            if (std::cin.fail())
+                {
+                    std::cin.clear();
                     std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
                     std::cout << "Entrada no válida. Intente de nuevo." << std::endl;
-                } else {
-                    break;
                 }
-            }
+            else
+                {
+                    // Verificar si hay caracteres no válidos en el búfer
+                    char c;
+                    std::cin.get(c);
+                    if (c != '\n' && !std::isdigit(c))
+                        {
+                            std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+                            std::cout << "Entrada no válida. Intente de nuevo." << std::endl;
+                        }
+                    else
+                        {
+                            break;
+                        }
+                }
         }
 
-        return entrada;
-    }
+    return entrada;
+}
 
 
 #endif // FUNC_ARCHIVOS_H_INCLUDED

--- a/func_utiles.h
+++ b/func_utiles.h
@@ -11,6 +11,9 @@ bool cargarCadenaConString(std::string input, char* output, size_t tamanioOutput
 /// Obtiene un entero con getline, dejando vacío el buffer de cin
 int obtenerNumeroEntero(std::string mensajeError="Valor incorrecto. Ingrese un número entero: ");
 
+/// Obtiene un decimal con getline, dejando vacío el buffer de cin
+float obtenerNumeroDecimal(std::string mensajeError="Valor incorrecto. Ingrese un número decimal: ");
+
 /// Valida datos de tipo int y float
 template<typename T>
 T validar(std::string mensaje)


### PR DESCRIPTION
Para que veamos esta alternativa, ya que tuve algunos errores con nuestros metodos de validacion:

Me pasaba que si el ingeso de datos era, por ejemplo: "4 a 4"
![Screenshot_20231107_201823](https://github.com/DiegoGonzalezPrieto/sistema-universitario/assets/94494799/656b95d1-e473-484d-b7ee-391d4206df53)

Si pueden probarlo y ver si se rompe o no...
Este nuevo método por ejemplo levantaría "132abc" como 123, pero no leería "abc123".